### PR TITLE
Change golang module name to match repo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,13 @@
-module gitlab.com/yawning/obfs4.git
+module github.com/jmwample/obfs4
 
 go 1.20
+
+replace gitlab.com/yawning/obfs4.git => ./
 
 require (
 	github.com/dchest/siphash v1.2.3
 	github.com/refraction-networking/conjure v0.4.5
+	gitlab.com/yawning/obfs4.git v0.0.0-20230519154740-645026c2ada4
 	gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/goptlib v1.4.0
 	golang.org/x/crypto v0.11.0
 	golang.org/x/net v0.12.0


### PR DESCRIPTION
despite this being a fork of the original obfs4 repo, changes in that repo make outside modification difficult to integrate.